### PR TITLE
Make `CommitPromise` pollable on any nodes

### DIFF
--- a/tests/fixed_scenario_test.rs
+++ b/tests/fixed_scenario_test.rs
@@ -183,11 +183,17 @@ fn truncate_log() {
     let reply = cluster
         .node0
         .asserted_handle_append_entries_call_success(&call);
-    assert!(commit_promise.poll(&cluster.node0).is_rejected());
+    assert!(commit_promise.poll(&cluster.node0).is_pending());
 
     cluster
         .node2
         .asserted_handle_append_entries_reply_success(&reply, true, false);
+
+    let (_, call) = cluster.node2.asserted_heartbeat();
+    let _reply = cluster
+        .node0
+        .asserted_handle_append_entries_call_success(&call);
+    assert!(commit_promise.poll(&cluster.node0).is_rejected());
 
     assert_no_action!(cluster.node0);
     assert_no_action!(cluster.node1);


### PR DESCRIPTION
This PR enables the transfer of `CommitPromise` from the leader node to any other node within the cluster.

Copilot Summary
------------------

This pull request includes changes to the `poll` method in `src/promise.rs` and updates to the `truncate_log` function in `tests/fixed_scenario_test.rs`. The most important changes involve refining the logic for handling commit promises and updating the test cases accordingly.

Changes to `poll` method logic:

* [`src/promise.rs`](diffhunk://#diff-c22bbb335644c380ad8220cc3d49463892c949236094911c1750dce19e68a20eR26-R44): Enhanced the `poll` method to handle additional cases for accepting or rejecting a promise based on the node's log entries and commit index. Added checks to reject promises if the term is outdated.

Updates to test cases:

* [`tests/fixed_scenario_test.rs`](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL186-R197): Updated the `truncate_log` test to reflect the new logic in the `poll` method. Changed assertions to check for pending state before ultimately rejecting the commit promise. Added steps to simulate heartbeat and handle append entries.