### PR TITLE
Implement `{From,Add,AddAssign,Sub,SubAssign}` traits for `{NodeId,Term,LogIndex}`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,3 +101,43 @@ impl Term {
         Self(self.0 + 1)
     }
 }
+
+impl From<u64> for Term {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<Term> for u64 {
+    fn from(value: Term) -> Self {
+        value.get()
+    }
+}
+
+impl std::ops::Add for Term {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for Term {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl std::ops::Sub for Term {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::SubAssign for Term {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}

--- a/src/log.rs
+++ b/src/log.rs
@@ -509,6 +509,46 @@ impl LogIndex {
     }
 }
 
+impl From<u64> for LogIndex {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<LogIndex> for u64 {
+    fn from(value: LogIndex) -> Self {
+        value.get()
+    }
+}
+
+impl std::ops::Add for LogIndex {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for LogIndex {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl std::ops::Sub for LogIndex {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::SubAssign for LogIndex {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
 /// Log position ([`Term`] and [`LogIndex`]).
 ///
 /// A [`LogPosition`] uniquely identifies a [`LogEntry`] stored within a cluster.

--- a/src/node.rs
+++ b/src/node.rs
@@ -30,6 +30,46 @@ impl NodeId {
     }
 }
 
+impl From<u64> for NodeId {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<NodeId> for u64 {
+    fn from(value: NodeId) -> Self {
+        value.get()
+    }
+}
+
+impl std::ops::Add for NodeId {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 + rhs.0)
+    }
+}
+
+impl std::ops::AddAssign for NodeId {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl std::ops::Sub for NodeId {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(self.0 - rhs.0)
+    }
+}
+
+impl std::ops::SubAssign for NodeId {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
+    }
+}
+
 /// Raft node.
 #[derive(Debug, Clone)]
 pub struct Node {


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces several new trait implementations to enhance the versatility of the `Term`, `LogIndex`, and `NodeId` types in the codebase. These changes primarily focus on adding conversion and arithmetic operations for these types.

Trait implementations for `Term`, `LogIndex`, and `NodeId`:

* Added `From<u64>` and `From<Term>` implementations to convert between `u64` and `Term`. (`src/lib.rs`)
* Added `std::ops::Add`, `std::ops::AddAssign`, `std::ops::Sub`, and `std::ops::SubAssign` implementations for `Term` to support arithmetic operations. (`src/lib.rs`)

* Added `From<u64>` and `From<LogIndex>` implementations to convert between `u64` and `LogIndex`. (`src/log.rs`)
* Added `std::ops::Add`, `std::ops::AddAssign`, `std::ops::Sub`, and `std::ops::SubAssign` implementations for `LogIndex` to support arithmetic operations. (`src/log.rs`)

* Added `From<u64>` and `From<NodeId>` implementations to convert between `u64` and `NodeId`. (`src/node.rs`)
* Added `std::ops::Add`, `std::ops::AddAssign`, `std::ops::Sub`, and `std::ops::SubAssign` implementations for `NodeId` to support arithmetic operations. (`src/node.rs`)