### PR TITLE
Once a snapshot is installed, adjust the pending messages to align with the snapshot.

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -473,6 +473,17 @@ impl LogEntries {
         }
         unreachable!();
     }
+
+    pub(crate) fn handle_snapshot_installed(&mut self, last_included_position: LogPosition) {
+        if last_included_position.index < self.prev_position().index {
+        } else if self.prev_position().index < last_included_position.index {
+            *self = Self::new(last_included_position);
+        } else {
+            *self = self
+                .since(last_included_position)
+                .expect("Node::handle_snapshot_installed() guarantees that this never happens");
+        }
+    }
 }
 
 impl std::iter::Extend<LogEntry> for LogEntries {

--- a/src/log.rs
+++ b/src/log.rs
@@ -476,7 +476,10 @@ impl LogEntries {
 
     pub(crate) fn handle_snapshot_installed(&mut self, last_included_position: LogPosition) {
         if last_included_position.index < self.prev_position().index {
-        } else if self.prev_position().index < last_included_position.index {
+            return;
+        }
+
+        if self.prev_position().index < last_included_position.index {
             *self = Self::new(last_included_position);
         } else {
             *self = self

--- a/src/message.rs
+++ b/src/message.rs
@@ -176,6 +176,13 @@ impl Message {
             *entries0 = entries1;
         }
     }
+
+    pub(crate) fn handle_snapshot_installed(&mut self, last_included_position: LogPosition) {
+        let Self::AppendEntriesCall { entries, .. } = self else {
+            return;
+        };
+        entries.handle_snapshot_installed(last_included_position);
+    }
 }
 
 /// Common header for all messages.

--- a/src/node.rs
+++ b/src/node.rs
@@ -1080,7 +1080,6 @@ impl Node {
         if let Some(entries) = &mut self.actions.append_log_entries {
             entries.handle_snapshot_installed(last_included_position);
         }
-
         if let Some(msg) = &mut self.actions.broadcast_message {
             msg.handle_snapshot_installed(last_included_position);
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1077,12 +1077,15 @@ impl Node {
             );
         }
 
-        if let Some(entries) = self.actions.append_log_entries.take() {
-            if last_included_position.index < entries.prev_position().index {
-                self.actions.append_log_entries = Some(entries);
-            } else {
-                self.actions.append_log_entries = entries.since(last_included_position);
-            }
+        if let Some(entries) = &mut self.actions.append_log_entries {
+            entries.handle_snapshot_installed(last_included_position);
+        }
+
+        if let Some(msg) = &mut self.actions.broadcast_message {
+            msg.handle_snapshot_installed(last_included_position);
+        }
+        for msg in self.actions.send_messages.values_mut() {
+            msg.handle_snapshot_installed(last_included_position);
         }
 
         true


### PR DESCRIPTION
Copilot Summary
------------------

This pull request introduces a new method `handle_snapshot_installed` to manage log entries and messages when a snapshot is installed. The changes ensure consistent handling of snapshots across different components of the system.

### Snapshot Handling Enhancements:

* [`src/log.rs`](diffhunk://#diff-bc4a99e9cd462bad7500082bec00a9ce3f5e71e8c68dfdb6566ff6a2c9b02415R476-R486): Added `handle_snapshot_installed` method to the `LogEntries` struct to update or reset log entries based on the last included position in the snapshot.

* [`src/message.rs`](diffhunk://#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704R179-R185): Introduced `handle_snapshot_installed` method in the `Message` struct to delegate snapshot handling to the `LogEntries` component.

* [`src/node.rs`](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L1080-R1088): Updated the `Node` struct to use the new `handle_snapshot_installed` method for both `append_log_entries` and various message actions, ensuring that all relevant components handle snapshots consistently.