### PR TITLE
Remove `HeartbeatPromise`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub use config::ClusterConfig;
 pub use log::{Log, LogEntries, LogEntry, LogIndex, LogPosition};
 pub use message::{Message, MessageHeader, MessageSeqNo};
 pub use node::{Node, NodeId};
-pub use promise::{CommitPromise, HeartbeatPromise};
+pub use promise::CommitPromise;
 pub use role::Role;
 
 /// Term.

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -1,4 +1,4 @@
-use crate::{LogPosition, MessageSeqNo, Node, Term};
+use crate::{LogPosition, Node};
 
 /// Promise of a commit that results in either rejection or acceptance.
 // TODO: struct CommitPromise(LogPosition);
@@ -69,59 +69,5 @@ impl CommitPromise {
     /// Returns [`true`] if the promise is accepted.
     pub fn is_accepted(self) -> bool {
         matches!(self, Self::Accepted(_))
-    }
-}
-
-/// Promise of a heartbeat that results in either rejection or acceptance.
-// TODO: consider to remove this enum
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum HeartbeatPromise {
-    /// The promise is pending.
-    ///
-    /// This state can be updated to either [`HeartbeatPromise::Accepted`] or [`HeartbeatPromise::Rejected`] by invoking [`HeartbeatPromise::poll()`].
-    Pending(Term, MessageSeqNo),
-
-    /// The promise is rejected.
-    Rejected,
-
-    /// The promise is accepted.
-    Accepted,
-}
-
-impl HeartbeatPromise {
-    pub(crate) fn new(term: Term, seqno: MessageSeqNo) -> Self {
-        Self::Pending(term, seqno)
-    }
-
-    /// Polls the promise to update its state.
-    ///
-    /// For convinience, the updated promise is returned.
-    pub fn poll(&mut self, node: &Node) -> Self {
-        let Self::Pending(term, seqno) = *self else {
-            return *self;
-        };
-        if node.current_term() != term {
-            *self = Self::Rejected;
-        } else if let Some(quorum) = node.quorum() {
-            if seqno <= quorum.smallest_majority_seqno() {
-                *self = Self::Accepted;
-            }
-        }
-        *self
-    }
-
-    /// Returns [`true`] if the promise is pending.
-    pub fn is_pending(self) -> bool {
-        matches!(self, Self::Pending { .. })
-    }
-
-    /// Returns [`true`] if the promise is rejected.
-    pub fn is_rejected(self) -> bool {
-        matches!(self, Self::Rejected)
-    }
-
-    /// Returns [`true`] if the promise is accepted.
-    pub fn is_accepted(self) -> bool {
-        matches!(self, Self::Accepted)
     }
 }

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -1,13 +1,10 @@
-use crate::{config::ClusterConfig, log::LogIndex, message::MessageSeqNo, node::NodeId};
+use crate::{config::ClusterConfig, log::LogIndex, node::NodeId};
 use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 pub struct Quorum {
     majority_indices: BTreeSet<(LogIndex, NodeId)>,
     new_majority_indices: BTreeSet<(LogIndex, NodeId)>,
-
-    majority_seqnos: BTreeSet<(MessageSeqNo, NodeId)>,
-    new_majority_seqnos: BTreeSet<(MessageSeqNo, NodeId)>,
 }
 
 impl Quorum {
@@ -26,27 +23,9 @@ impl Quorum {
             .copied()
             .map(|id| (LogIndex::new(0), id))
             .collect::<BTreeSet<_>>();
-
-        let majority_seqnos = config
-            .voters
-            .iter()
-            .take(config.voters.len() / 2 + 1)
-            .copied()
-            .map(|id| (MessageSeqNo::ZERO, id))
-            .collect::<BTreeSet<_>>();
-        let new_majority_seqnos = config
-            .new_voters
-            .iter()
-            .take(config.new_voters.len() / 2 + 1)
-            .copied()
-            .map(|id| (MessageSeqNo::ZERO, id))
-            .collect::<BTreeSet<_>>();
-
         Self {
             majority_indices,
             new_majority_indices,
-            majority_seqnos,
-            new_majority_seqnos,
         }
     }
 
@@ -67,37 +46,6 @@ impl Quorum {
         }
         if config.new_voters.contains(&node_id) {
             update_majority(&mut self.new_majority_indices, old_entry, new_entry);
-        }
-    }
-
-    pub fn update_seqno(
-        &mut self,
-        config: &ClusterConfig,
-        node_id: NodeId,
-        old_seqno: MessageSeqNo,
-        seqno: MessageSeqNo,
-    ) {
-        debug_assert!(old_seqno <= seqno);
-
-        let old_entry = (old_seqno, node_id);
-        let new_entry = (seqno, node_id);
-
-        if config.voters.contains(&node_id) {
-            update_majority(&mut self.majority_seqnos, old_entry, new_entry);
-        }
-        if config.new_voters.contains(&node_id) {
-            update_majority(&mut self.new_majority_seqnos, old_entry, new_entry);
-        }
-    }
-
-    pub fn smallest_majority_seqno(&self) -> MessageSeqNo {
-        let Some(i0) = self.majority_seqnos.first().map(|(i, _)| *i) else {
-            unreachable!();
-        };
-        if let Some(i1) = self.new_majority_seqnos.first().map(|(i, _)| *i) {
-            i0.min(i1)
-        } else {
-            i0
         }
     }
 

--- a/tests/random_scenario_test.rs
+++ b/tests/random_scenario_test.rs
@@ -211,8 +211,7 @@ fn pipelining() {
         };
         promises.push(leader.propose_command());
         if do_hearbeat {
-            let promise = leader.heartbeat();
-            assert!(promise.is_pending());
+            assert!(leader.heartbeat());
         }
 
         if !pipeline_command {


### PR DESCRIPTION
Commit Promise
-----------------

This pull request includes several changes to the `raftbare` project, primarily focusing on removing the `HeartbeatPromise` and simplifying related code. The most important changes include updates to the `Node` and `Quorum` implementations, as well as modifications to the test files to reflect these changes.

### Removal of `HeartbeatPromise`:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L79-R79): Removed the re-export of `HeartbeatPromise`.
* [`src/node.rs`](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L610-R623): Updated the `heartbeat` method to return a boolean instead of a `HeartbeatPromise` and removed related logic. [[1]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L610-R623) [[2]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L644-R635)
* [`src/promise.rs`](diffhunk://#diff-c22bbb335644c380ad8220cc3d49463892c949236094911c1750dce19e68a20eL1-R1): Removed the `HeartbeatPromise` enum and its associated methods. [[1]](diffhunk://#diff-c22bbb335644c380ad8220cc3d49463892c949236094911c1750dce19e68a20eL1-R1) [[2]](diffhunk://#diff-c22bbb335644c380ad8220cc3d49463892c949236094911c1750dce19e68a20eL74-L127)
* [`tests/fixed_scenario_test.rs`](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL106-L111): Updated tests to reflect the removal of `HeartbeatPromise`. [[1]](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL106-L111) [[2]](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL192-R191) [[3]](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL241-R240) [[4]](diffhunk://#diff-9cf1a9a73eccc680340bb691c1d02f1e9c286cc2c8f894de27c08277594e432bL769-R774)
* [`tests/random_scenario_test.rs`](diffhunk://#diff-b0c5a2b2378e888b10acff5b16e551f3cccd433d37583244e0fd3571fc1f94f1L214-R214): Updated the `pipelining` test to reflect the removal of `HeartbeatPromise`.

### Simplification of `Quorum`:

* [`src/quorum.rs`](diffhunk://#diff-facd30220ff5f7453b2907961b36f2cf9134c04c57139f690a8b0cb3e170b2c6L1-L10): Removed methods and fields related to sequence numbers (`MessageSeqNo`) in the `Quorum` struct. [[1]](diffhunk://#diff-facd30220ff5f7453b2907961b36f2cf9134c04c57139f690a8b0cb3e170b2c6L1-L10) [[2]](diffhunk://#diff-facd30220ff5f7453b2907961b36f2cf9134c04c57139f690a8b0cb3e170b2c6L29-L49) [[3]](diffhunk://#diff-facd30220ff5f7453b2907961b36f2cf9134c04c57139f690a8b0cb3e170b2c6L73-L103)

### Additional Changes:

* [`src/node.rs`](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L7-R7): Removed unused imports and redundant method calls related to sequence numbers. [[1]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L7-R7) [[2]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L507-L511) [[3]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L922-L927) [[4]](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13L1107-R1093)