### PR TITLE
Remove unnecessary `Action::AppendLogEntries` after snapshot

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1085,6 +1085,11 @@ impl Node {
         if let Some(entries) = &mut self.actions.append_log_entries {
             entries.handle_snapshot_installed(last_included_position);
         }
+        let _ = self
+            .actions
+            .append_log_entries
+            .take_if(|entries| entries.is_empty());
+
         if let Some(msg) = &mut self.actions.broadcast_message {
             msg.handle_snapshot_installed(last_included_position);
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1084,11 +1084,10 @@ impl Node {
 
         if let Some(entries) = &mut self.actions.append_log_entries {
             entries.handle_snapshot_installed(last_included_position);
+            if entries.is_empty() {
+                self.actions.append_log_entries = None;
+            }
         }
-        let _ = self
-            .actions
-            .append_log_entries
-            .take_if(|entries| entries.is_empty());
 
         if let Some(msg) = &mut self.actions.broadcast_message {
             msg.handle_snapshot_installed(last_included_position);


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes a change to the `impl Node` in the `src/node.rs` file. The change ensures that the `append_log_entries` are properly handled when they are empty.

Codebase improvement:

* [`src/node.rs`](diffhunk://#diff-af08c3181737aa5783b96dfd920cd5ef70829f46cd1b697bdb42414c97310e13R1088-R1092): Added a check to take and handle `append_log_entries` only if they are empty.