### PR TITLE
Clean up CI configuration and fix Clippy/formatting warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
       - run: rustup default ${{ matrix.toolchain }}
       - run: rustup component add rustfmt clippy
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all -- -D warnings
+      - run: cargo clippy --all --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly]
+        toolchain: [stable]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/tests/fixed_scenario_test.rs
+++ b/tests/fixed_scenario_test.rs
@@ -532,7 +532,6 @@ impl TestNode {
                             cluster_config_entry(joint(initial_voters, &[])),
                             term_entry(t(1))
                         ]
-                        .into_iter()
                     ))
                 );
             } else {
@@ -541,7 +540,7 @@ impl TestNode {
                     node,
                     append_log_entries(&LogEntries::from_iter(
                         prev(t(0), i(0)),
-                        [cluster_config_entry(joint(initial_voters, &[]))].into_iter()
+                        [cluster_config_entry(joint(initial_voters, &[]))]
                     ))
                 );
                 assert!(matches!(
@@ -609,7 +608,7 @@ impl TestNode {
 
         let reply = append_entries_reply(msg, self);
         if !entries.is_empty() {
-            assert_action!(self, append_log_entries(&entries));
+            assert_action!(self, append_log_entries(entries));
         }
         if prev_commit_index < *leader_commit
             && prev_commit_index <= self.log().entries().last_position().index
@@ -872,7 +871,7 @@ impl TestNode {
 
         let tail = self.log().entries().last_position();
         self.handle_message(msg);
-        let reply = append_entries_reply(&msg, self);
+        let reply = append_entries_reply(msg, self);
         assert_action!(self, save_current_term());
         assert_eq!(self.current_term(), msg.term());
         assert_action!(self, save_voted_for());
@@ -1070,7 +1069,7 @@ fn next_same_kind_action(actions: &mut Actions, expected: &Action) -> Option<Act
         Action::InstallSnapshot(node_id) => actions
             .install_snapshots
             .remove(node_id)
-            .then(|| Action::InstallSnapshot(*node_id)),
+            .then_some(Action::InstallSnapshot(*node_id)),
         _ => None,
     }
 }

--- a/tests/random_scenario_test.rs
+++ b/tests/random_scenario_test.rs
@@ -433,7 +433,7 @@ fn dynamic_membership() {
 
     for i in 0..10 {
         // Change the cluster configuration.
-        cluster.run_while_leader_absent(cluster.clock.add(1000_000));
+        cluster.run_while_leader_absent(cluster.clock.add(1_000_000));
         if cluster.rng.random_bool(0.7) {
             // Add.
             let node_id = NodeId::new(3 + i);
@@ -483,7 +483,7 @@ fn dynamic_membership() {
         // Propose commands.
         let mut positions = Vec::new();
         for _ in 0..10 {
-            cluster.run_while_leader_absent(cluster.clock.add(1000_000));
+            cluster.run_while_leader_absent(cluster.clock.add(1_000_000));
             let Some(leader) = cluster.leader_node_mut() else {
                 panic!("No leader");
             };
@@ -497,7 +497,7 @@ fn dynamic_membership() {
         let mut success_count = 0;
         for position in positions {
             for _ in 0..20000 {
-                cluster.run_while_leader_absent(cluster.clock.add(1000_000));
+                cluster.run_while_leader_absent(cluster.clock.add(1_000_000));
                 let Some(leader) = cluster.leader_node_mut() else {
                     panic!("No leader");
                 };
@@ -560,7 +560,7 @@ fn truncate_divergence_log() {
     let old_leader = cluster.nodes.remove(leader_node_index);
 
     // Elect a new leader.
-    cluster.run_while_leader_absent(cluster.clock.add(1000_000));
+    cluster.run_while_leader_absent(cluster.clock.add(1_000_000));
 
     // Propose remaining commands.
     for _ in 0..60 {


### PR DESCRIPTION
This PR makes several improvements to the codebase:

**CI/Workflow Changes:**
- Reduce test matrix to `stable` toolchain only (removed `beta` and `nightly`)
- Update Clippy to check all targets including tests via `--all-targets` flag

**Code Cleanup:**
- Remove unnecessary `.into_iter()` calls on arrays (let the iterator be inferred)
- Replace deprecated `.then()` with `.then_some()` for better intent clarity
- Fix numeric literal formatting to use underscores for readability (e.g., `1000_000` → `1_000_000`)
- Remove unnecessary reference operators on function arguments where values can be passed directly

All changes are driven by Clippy warnings and improve code idiomaticity and readability.
