### PR TITLE
Add `Message::strip_append_entries_prefix()` method to efficiently trim sent log entries

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -60,6 +60,8 @@ pub enum Action {
     ///
     /// Additionally, if an AppendEntriesRPC contains too many entries to be sent in a single message,
     /// they can be safely truncated using [`LogEntries::truncate()`](crate::LogEntries::truncate) before sending the message.
+    /// And after sending a part of entries, the sent prefix can be dropped by
+    /// calling [`Message::strip_append_entries_prefix()`](crate::Message::strip_append_entries_prefix).
     SendMessage(NodeId, Message),
 
     /// Install a snapshot on a specific node.

--- a/src/message.rs
+++ b/src/message.rs
@@ -49,7 +49,9 @@ pub enum Message {
         /// Entries to append.
         ///
         /// Note that if the entries are too large to fit in a single message,
-        /// it can be shrinked by calling [`LogEntries::truncate()`] before sending.
+        /// they can be shrunk by calling [`LogEntries::truncate()`] before sending.
+        /// Also, after sending a part of entries, the sent prefix can be dropped by
+        /// calling [`Message::strip_append_entries_prefix()`].
         entries: LogEntries,
     },
 
@@ -93,6 +95,41 @@ impl Message {
             Self::AppendEntriesCall { term, .. } => *term,
             Self::AppendEntriesReply { term, .. } => *term,
         }
+    }
+
+    /// Drops the first `sent_count` entries if this is an [`Message::AppendEntriesCall`].
+    ///
+    /// Returns [`true`] when this is an [`Message::AppendEntriesCall`], otherwise returns [`false`]
+    /// and does not modify the message.
+    ///
+    /// If `sent_count` is `0`, this method has no effect.
+    /// If `sent_count` is greater than or equal to the number of entries, all entries are dropped.
+    pub fn strip_append_entries_prefix(&mut self, sent_count: usize) -> bool {
+        let Self::AppendEntriesCall { entries, .. } = self else {
+            return false;
+        };
+
+        if sent_count == 0 {
+            return true;
+        }
+        if sent_count >= entries.len() {
+            *entries = LogEntries::new(entries.last_position());
+            return true;
+        }
+
+        let new_prev_index =
+            LogIndex::new(entries.prev_position().index.get() + sent_count as u64);
+        let new_prev_term = entries.get_term(new_prev_index).expect(
+            "sent_count is less than the number of entries, so the new previous index is always valid",
+        );
+        let new_prev_position = LogPosition {
+            term: new_prev_term,
+            index: new_prev_index,
+        };
+        *entries = entries.since(new_prev_position).expect(
+            "new previous position is derived from the current entries, so it is always valid",
+        );
+        true
     }
 
     pub(crate) fn request_vote_call(term: Term, from: NodeId, last_position: LogPosition) -> Self {
@@ -205,5 +242,131 @@ impl Message {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{LogEntry, Term};
+
+    use super::*;
+
+    #[test]
+    fn strip_append_entries_prefix_for_append_entries_call() {
+        let from = NodeId::new(1);
+        let term = Term::new(3);
+        let commit_index = LogIndex::new(5);
+        let prev = LogPosition {
+            term: Term::new(2),
+            index: LogIndex::new(10),
+        };
+        let entries = LogEntries::from_iter(
+            prev,
+            [
+                LogEntry::Command,
+                LogEntry::Term(Term::new(3)),
+                LogEntry::Command,
+            ],
+        );
+        let mut message = Message::append_entries_call(term, from, commit_index, entries);
+
+        assert!(message.strip_append_entries_prefix(1));
+        let Message::AppendEntriesCall { entries, .. } = &message else {
+            panic!();
+        };
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries.prev_position(),
+            LogPosition {
+                term: Term::new(2),
+                index: LogIndex::new(11),
+            }
+        );
+        assert_eq!(
+            entries.last_position(),
+            LogPosition {
+                term: Term::new(3),
+                index: LogIndex::new(13),
+            }
+        );
+        assert_eq!(
+            entries.iter().collect::<Vec<_>>(),
+            vec![LogEntry::Term(Term::new(3)), LogEntry::Command]
+        );
+    }
+
+    #[test]
+    fn strip_append_entries_prefix_with_zero_len() {
+        let from = NodeId::new(1);
+        let term = Term::new(3);
+        let commit_index = LogIndex::new(5);
+        let prev = LogPosition {
+            term: Term::new(2),
+            index: LogIndex::new(10),
+        };
+        let original_entries = LogEntries::from_iter(prev, [LogEntry::Command, LogEntry::Command]);
+        let mut message =
+            Message::append_entries_call(term, from, commit_index, original_entries.clone());
+
+        assert!(message.strip_append_entries_prefix(0));
+        let Message::AppendEntriesCall {
+            entries: current_entries,
+            ..
+        } = &message
+        else {
+            panic!();
+        };
+        assert_eq!(current_entries, &original_entries);
+    }
+
+    #[test]
+    fn strip_append_entries_prefix_drops_all_entries() {
+        let from = NodeId::new(1);
+        let term = Term::new(3);
+        let commit_index = LogIndex::new(5);
+        let prev = LogPosition {
+            term: Term::new(2),
+            index: LogIndex::new(10),
+        };
+        let entries = LogEntries::from_iter(
+            prev,
+            [LogEntry::Command, LogEntry::Term(Term::new(3)), LogEntry::Command],
+        );
+        let old_last_position = entries.last_position();
+        let mut message = Message::append_entries_call(term, from, commit_index, entries);
+
+        assert!(message.strip_append_entries_prefix(3));
+        let Message::AppendEntriesCall { entries, .. } = &message else {
+            panic!();
+        };
+        assert!(entries.is_empty());
+        assert_eq!(entries.prev_position(), old_last_position);
+        assert_eq!(entries.last_position(), old_last_position);
+
+        assert!(message.strip_append_entries_prefix(usize::MAX));
+        let Message::AppendEntriesCall { entries, .. } = &message else {
+            panic!();
+        };
+        assert!(entries.is_empty());
+        assert_eq!(entries.prev_position(), old_last_position);
+        assert_eq!(entries.last_position(), old_last_position);
+    }
+
+    #[test]
+    fn strip_append_entries_prefix_non_append_entries_call_is_noop() {
+        let from = NodeId::new(1);
+        let term = Term::new(3);
+        let mut request_vote = Message::request_vote_call(
+            term,
+            from,
+            LogPosition {
+                term,
+                index: LogIndex::new(5),
+            },
+        );
+        let original = request_vote.clone();
+
+        assert!(!request_vote.strip_append_entries_prefix(1));
+        assert_eq!(request_vote, original);
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -117,8 +117,7 @@ impl Message {
             return true;
         }
 
-        let new_prev_index =
-            LogIndex::new(entries.prev_position().index.get() + sent_count as u64);
+        let new_prev_index = LogIndex::new(entries.prev_position().index.get() + sent_count as u64);
         let new_prev_term = entries.get_term(new_prev_index).expect(
             "sent_count is less than the number of entries, so the new previous index is always valid",
         );
@@ -330,7 +329,11 @@ mod tests {
         };
         let entries = LogEntries::from_iter(
             prev,
-            [LogEntry::Command, LogEntry::Term(Term::new(3)), LogEntry::Command],
+            [
+                LogEntry::Command,
+                LogEntry::Term(Term::new(3)),
+                LogEntry::Command,
+            ],
         );
         let old_last_position = entries.last_position();
         let mut message = Message::append_entries_call(term, from, commit_index, entries);


### PR DESCRIPTION
This PR introduces a new method `strip_append_entries_prefix()` to the `Message` type that allows dropping already-sent entries from `AppendEntriesCall` messages. This is useful when log entries are too large to fit in a single message and need to be sent in multiple parts.

**Key changes:**
- Added `strip_append_entries_prefix(&mut self, sent_count: usize) -> bool` method that safely removes the first N entries from an `AppendEntriesCall` message
- Updates `prev_position` to reflect the new first entry after truncation
- Returns `true` for `AppendEntriesCall` (and modifies the message), `false` for other message types
- Includes comprehensive documentation with examples
- Adds 4 unit tests covering: normal truncation, zero-length truncation, dropping all entries, and non-applicable message types
- Updated documentation in `action.rs` and `message.rs` to reference the new method
