### PR TITLE
Switch to `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,11 @@ name = "noraft"
 version = "0.4.1"
 edition = "2024"
 license = "MIT"
-description = "Minimal, feature-complete Raft for Rust - no I/O, no dependencies"
+description = "Minimal, feature-complete no_std Raft for Rust - no I/O, no dependencies"
 homepage = "https://github.com/sile/noraft"
 repository = "https://github.com/sile/noraft"
 readme = "README.md"
+categories = ["algorithms", "no-std"]
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ noraft
 ![License](https://img.shields.io/crates/l/noraft)
 
 
-noraft: Minimal, feature-complete Raft for Rust - no I/O, no dependencies.
+noraft: Minimal, feature-complete no_std Raft for Rust - no I/O, no dependencies.
 
-`noraft` is a minimal but feature-complete, sans I/O implementation of the [Raft] distributed consensus algorithm.
+`noraft` is a minimal but feature-complete, `no_std`, sans I/O implementation of the [Raft] distributed consensus algorithm.
 
 [Raft]: https://raft.github.io/
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,5 @@
 use crate::{log::LogEntries, message::Message, node::NodeId};
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 /// [`Action`] represents the I/O operations for [`Node`](crate::Node) that crate users need to execute.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -231,11 +231,11 @@ mod tests {
         // AppendLogEntries
         actions.set(Action::AppendLogEntries(LogEntries::from_iter(
             pos(2, 3),
-            std::iter::once(LogEntry::Command),
+            core::iter::once(LogEntry::Command),
         )));
         actions.set(Action::AppendLogEntries(LogEntries::from_iter(
             pos(2, 4),
-            std::iter::once(LogEntry::Command),
+            core::iter::once(LogEntry::Command),
         )));
         assert_eq!(
             actions.next(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,9 @@
 use crate::node::NodeId;
-use std::{
-    collections::{
-        BTreeSet,
-        btree_set::{Iter, Union},
-    },
-    iter::Peekable,
+use alloc::collections::{
+    BTreeSet,
+    btree_set::{Iter, Union},
 };
+use core::iter::Peekable;
 
 /// Cluster configuration (membership).
 ///
@@ -180,6 +178,7 @@ impl Iterator for UniqueNodes<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn unique_nodes() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! noraft: Minimal, feature-complete Raft for Rust - no I/O, no dependencies.
+//! noraft: Minimal, feature-complete no_std Raft for Rust - no I/O, no dependencies.
 //!
 //! [Raft]: https://raft.github.io/
 //!
@@ -63,8 +63,14 @@
 //! # fn is_election_timeout_expired() -> bool { true }
 //! # fn try_receive_message() -> Option<noraft::Message> { None }
 //! ```
+#![no_std]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
 
 mod action;
 mod config;
@@ -116,7 +122,7 @@ impl From<Term> for u64 {
     }
 }
 
-impl std::ops::Add for Term {
+impl core::ops::Add for Term {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -124,13 +130,13 @@ impl std::ops::Add for Term {
     }
 }
 
-impl std::ops::AddAssign for Term {
+impl core::ops::AddAssign for Term {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl std::ops::Sub for Term {
+impl core::ops::Sub for Term {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -138,7 +144,7 @@ impl std::ops::Sub for Term {
     }
 }
 
-impl std::ops::SubAssign for Term {
+impl core::ops::SubAssign for Term {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,5 @@
 use crate::{Term, config::ClusterConfig};
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 /// In-memory representation of a [`Node`][crate::Node] local log.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -526,7 +526,7 @@ impl LogEntries {
     }
 }
 
-impl std::iter::Extend<LogEntry> for LogEntries {
+impl core::iter::Extend<LogEntry> for LogEntries {
     fn extend<T: IntoIterator<Item = LogEntry>>(&mut self, iter: T) {
         for entry in iter {
             self.push(entry);
@@ -572,7 +572,7 @@ impl From<LogIndex> for u64 {
     }
 }
 
-impl std::ops::Add for LogIndex {
+impl core::ops::Add for LogIndex {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -580,13 +580,13 @@ impl std::ops::Add for LogIndex {
     }
 }
 
-impl std::ops::AddAssign for LogIndex {
+impl core::ops::AddAssign for LogIndex {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl std::ops::Sub for LogIndex {
+impl core::ops::Sub for LogIndex {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -594,7 +594,7 @@ impl std::ops::Sub for LogIndex {
     }
 }
 
-impl std::ops::SubAssign for LogIndex {
+impl core::ops::SubAssign for LogIndex {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }
@@ -699,7 +699,8 @@ impl CommitStatus {
 mod tests {
     use super::*;
     use crate::NodeId;
-    use std::collections::BTreeSet;
+    use alloc::collections::BTreeSet;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn log_entries_append() {
@@ -859,11 +860,11 @@ mod tests {
 
     #[test]
     fn log_position_cmp() {
-        assert_eq!(pos(5, 5).cmp(&pos(5, 5)), std::cmp::Ordering::Equal);
-        assert_eq!(pos(7, 3).cmp(&pos(5, 5)), std::cmp::Ordering::Greater);
-        assert_eq!(pos(3, 7).cmp(&pos(5, 5)), std::cmp::Ordering::Less);
-        assert_eq!(pos(5, 7).cmp(&pos(5, 5)), std::cmp::Ordering::Greater);
-        assert_eq!(pos(5, 3).cmp(&pos(5, 5)), std::cmp::Ordering::Less);
+        assert_eq!(pos(5, 5).cmp(&pos(5, 5)), core::cmp::Ordering::Equal);
+        assert_eq!(pos(7, 3).cmp(&pos(5, 5)), core::cmp::Ordering::Greater);
+        assert_eq!(pos(3, 7).cmp(&pos(5, 5)), core::cmp::Ordering::Less);
+        assert_eq!(pos(5, 7).cmp(&pos(5, 5)), core::cmp::Ordering::Greater);
+        assert_eq!(pos(5, 3).cmp(&pos(5, 5)), core::cmp::Ordering::Less);
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -249,6 +249,7 @@ mod tests {
     use crate::{LogEntry, Term};
 
     use super::*;
+    use alloc::{vec, vec::Vec};
 
     #[test]
     fn strip_append_entries_prefix_for_append_entries_call() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -6,7 +6,7 @@ use crate::{
     message::Message,
     quorum::Quorum,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use alloc::collections::{BTreeMap, BTreeSet};
 
 /// Node identifier ([`u64`]).
 ///
@@ -42,7 +42,7 @@ impl From<NodeId> for u64 {
     }
 }
 
-impl std::ops::Add for NodeId {
+impl core::ops::Add for NodeId {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -50,13 +50,13 @@ impl std::ops::Add for NodeId {
     }
 }
 
-impl std::ops::AddAssign for NodeId {
+impl core::ops::AddAssign for NodeId {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl std::ops::Sub for NodeId {
+impl core::ops::Sub for NodeId {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -64,7 +64,7 @@ impl std::ops::Sub for NodeId {
     }
 }
 
-impl std::ops::SubAssign for NodeId {
+impl core::ops::SubAssign for NodeId {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }
@@ -250,7 +250,7 @@ impl Node {
         self.actions
             .set(Action::AppendLogEntries(LogEntries::from_iter(
                 LogPosition::ZERO,
-                std::iter::once(entry.clone()),
+                core::iter::once(entry.clone()),
             )));
         self.log.entries_mut().push(entry.clone());
 
@@ -381,7 +381,7 @@ impl Node {
         }
 
         self.role = RoleState::Candidate {
-            granted_votes: std::iter::once(self.id).collect(),
+            granted_votes: core::iter::once(self.id).collect(),
         };
 
         self.actions
@@ -501,7 +501,7 @@ impl Node {
                 self.current_term,
                 self.id,
                 self.commit_index,
-                LogEntries::from_iter(old_last_position, std::iter::once(entry)),
+                LogEntries::from_iter(old_last_position, core::iter::once(entry)),
             );
             self.actions.set(Action::BroadcastMessage(call));
         }
@@ -599,7 +599,7 @@ impl Node {
         debug_assert!(self.log.latest_config().is_joint_consensus());
 
         let mut new_config = self.log.latest_config().clone();
-        new_config.voters = std::mem::take(&mut new_config.new_voters);
+        new_config.voters = core::mem::take(&mut new_config.new_voters);
         debug_assert!(!new_config.voters.is_empty());
 
         self.propose(LogEntry::ClusterConfig(new_config));
@@ -713,7 +713,7 @@ impl Node {
         self.actions
             .set(Action::AppendLogEntries(LogEntries::from_iter(
                 self.log.last_position(),
-                std::iter::once(entry.clone()),
+                core::iter::once(entry.clone()),
             )));
         self.log.entries_mut().push(entry.clone());
 

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -1,5 +1,5 @@
 use crate::{config::ClusterConfig, log::LogIndex, node::NodeId};
-use std::collections::BTreeSet;
+use alloc::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 pub struct Quorum {


### PR DESCRIPTION
Adds `#![no_std]` unconditionally (no feature flag). The crate uses `alloc` for `BTreeMap`/`BTreeSet` and `core` for `ops`/`iter`/`mem`/`cmp`; there was no I/O, no time, and no threading in the crate to begin with.

Verified with `cargo test`, `cargo clippy --all-targets -D warnings`, and `cargo check --target thumbv6m-none-eabi`.

Also updates the crate description, `categories`, and README tagline to mention `no_std`.