### PR TITLE
Fix conservative log repair after out-of-range common-prefix detection

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -46,6 +46,9 @@ pub enum Action {
     ///
     /// Note that previously written log suffix entries may be overwritten by these new entries.
     /// In other words, the [`LogEntries::last_position().index`](crate::LogEntries::last_position) can be any value within the range from the start index to the end index of the local log.
+    /// The supplied entries are not guaranteed to be the minimal missing suffix.
+    /// They may include entries that are already present in storage when the node chooses a conservative common prefix to repair divergence.
+    /// Implementations should treat [`LogEntries::prev_position()`](crate::LogEntries::prev_position) as the overwrite anchor and replace the persisted suffix after that position with these entries.
     ///
     /// To guarantee properties by the Raft algorithm, the entries must be appended before responding to users or other nodes.
     /// (However, because writing all log entries to persistent storage synchronously could be too costly, in reality, the entries are often written asynchronously.)

--- a/src/log.rs
+++ b/src/log.rs
@@ -479,15 +479,30 @@ impl LogEntries {
                 .expect("unreachable");
         }
 
+        // This method only best-effort minimizes the delta to append.
+        // It keeps the latest position that is proven to be common, and
+        // `append()` will truncate the local suffix after that position.
         let mut last_common_position = self.prev_position;
         for (&index, &term) in &self.terms {
             let position = LogPosition { term, index };
-            if !local_entries.contains(position) {
-                last_common_position.index = LogIndex::new(index.get() - 1);
-                debug_assert!(local_entries.contains(last_common_position));
-                return self.since(last_common_position).expect("unreachable");
+            if local_entries.contains(position) {
+                last_common_position = position;
+                continue;
             }
-            last_common_position.term = term;
+
+            // The entry immediately before a mismatching Term boundary may
+            // still be common, but that boundary can also be beyond the local
+            // range. Only use the predecessor after verifying it locally.
+            let candidate = LogPosition {
+                term: last_common_position.term,
+                index: LogIndex::new(index.get() - 1),
+            };
+            if local_entries.contains(candidate) {
+                last_common_position = candidate;
+            }
+            return self
+                .since(last_common_position)
+                .expect("last_common_position is derived from this log");
         }
 
         // self.terms is empty
@@ -855,6 +870,34 @@ mod tests {
                 .strip_common_prefix(&local_entries)
                 .prev_position,
             pos(1, 4)
+        );
+    }
+
+    #[test]
+    fn log_entries_strip_common_prefix_falls_back_when_term_is_outside_local_range() {
+        let local_entries = entries(
+            LogPosition::ZERO,
+            &[
+                LogEntry::Term(Term::new(1)),
+                LogEntry::Command,
+                LogEntry::Command,
+                LogEntry::Term(Term::new(3)),
+            ],
+        );
+        let remote_entries = entries(
+            pos(1, 3),
+            &[
+                LogEntry::Command,
+                LogEntry::Command,
+                LogEntry::Term(Term::new(2)),
+            ],
+        );
+
+        assert!(local_entries.contains(remote_entries.prev_position()));
+        assert!(!local_entries.contains(remote_entries.last_position()));
+        assert_eq!(
+            remote_entries.strip_common_prefix(&local_entries),
+            remote_entries
         );
     }
 

--- a/tests/fixed_scenario_test.rs
+++ b/tests/fixed_scenario_test.rs
@@ -582,6 +582,70 @@ fn same_index_different_term_tail_is_truncated_before_replication() {
 }
 
 #[test]
+fn follower_rewrites_from_common_prefix_when_repair_term_is_outside_local_log() {
+    let leader_term = t(4);
+    let follower_log = Log::new(
+        ClusterConfig::new(),
+        LogEntries::from_iter(
+            LogPosition::ZERO,
+            [
+                term_entry(t(1)),
+                LogEntry::Command,
+                LogEntry::Command,
+                term_entry(t(3)),
+            ],
+        ),
+    );
+    let mut follower = TestNode {
+        inner: Node::restart(
+            id(1),
+            NodeGeneration::new(1),
+            leader_term,
+            Some(id(0)),
+            follower_log,
+        ),
+        actions: Actions::default(),
+    };
+    assert_action!(follower, set_election_timeout());
+    assert_no_action!(follower);
+
+    let repair_entries = LogEntries::from_iter(
+        log_pos(t(1), i(3)),
+        [LogEntry::Command, LogEntry::Command, term_entry(t(2))],
+    );
+    let repair_call = Message::AppendEntriesCall {
+        from: id(0),
+        term: leader_term,
+        commit_index: i(6),
+        entries: repair_entries.clone(),
+    };
+
+    follower.handle_message(&repair_call);
+
+    let reply = append_entries_reply(&repair_call, &follower);
+    assert_eq!(follower.commit_index(), i(6));
+    assert_eq!(
+        follower
+            .log()
+            .entries()
+            .iter_with_positions()
+            .collect::<Vec<_>>(),
+        vec![
+            (log_pos(t(1), i(1)), term_entry(t(1))),
+            (log_pos(t(1), i(2)), LogEntry::Command),
+            (log_pos(t(1), i(3)), LogEntry::Command),
+            (log_pos(t(1), i(4)), LogEntry::Command),
+            (log_pos(t(1), i(5)), LogEntry::Command),
+            (log_pos(t(2), i(6)), term_entry(t(2))),
+        ]
+    );
+    assert_action!(follower, append_log_entries(&repair_entries));
+    assert_action!(follower, send_message(id(0), &reply));
+    assert_action!(follower, set_election_timeout());
+    assert_no_action!(follower);
+}
+
+#[test]
 fn snapshot() {
     let mut cluster = ThreeNodeCluster::new();
     cluster.init_cluster();


### PR DESCRIPTION
## Summary

- Fix `strip_common_prefix()` so it only uses locally verified common positions when shrinking repair entries.
- Fall back to a conservative overwrite anchor when a mismatching `Term` boundary is outside the local log range.
- Document that `Action::AppendLogEntries` may contain a non-minimal suffix and must be persisted as a suffix overwrite from `prev_position()`.
