### PR TITLE
Recompute solo-voter state after configuration changes

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -351,8 +351,7 @@ impl Node {
 
         let quorum = Quorum::new(self.config());
         let followers = BTreeMap::new();
-        let solo_voter =
-            self.config().unique_voters().count() == 1 && self.config().voters.contains(&self.id);
+        let solo_voter = self.is_self_solo_voter();
         self.role = RoleState::Leader {
             followers,
             quorum,
@@ -364,6 +363,17 @@ impl Node {
         self.propose(LogEntry::Term(self.current_term));
     }
 
+    fn is_self_solo_voter(&self) -> bool {
+        self.config().unique_voters().count() == 1 && self.config().voters.contains(&self.id)
+    }
+
+    fn refresh_solo_voter(&mut self) {
+        let is_self_solo_voter = self.is_self_solo_voter();
+        if let RoleState::Leader { solo_voter, .. } = &mut self.role {
+            *solo_voter = is_self_solo_voter;
+        }
+    }
+
     fn transition_to_candidate(&mut self) {
         if !self.log.latest_config().is_voter(self.id) {
             // Non voter or removed node cannot become a candidate.
@@ -373,8 +383,7 @@ impl Node {
         self.set_current_term(self.current_term.next());
         self.set_voted_for(Some(self.id));
 
-        let solo_voter =
-            self.config().unique_voters().count() == 1 && self.config().voters.contains(&self.id);
+        let solo_voter = self.is_self_solo_voter();
         if solo_voter {
             self.transition_to_leader();
             return;
@@ -727,6 +736,7 @@ impl Node {
         if matches!(entry, LogEntry::ClusterConfig(_)) {
             self.rebuild_followers();
             self.rebuild_quorum();
+            self.refresh_solo_voter();
         }
 
         if matches!(

--- a/tests/fixed_scenario_test.rs
+++ b/tests/fixed_scenario_test.rs
@@ -62,6 +62,63 @@ fn create_two_nodes_cluster() {
 }
 
 #[test]
+fn leader_commits_after_shrinking_to_self_only_voter() {
+    let initial_voters = [id(0), id(1)];
+    let mut leader = TestNode::asserted_start(id(0), &initial_voters);
+    let mut follower = TestNode::asserted_start(id(1), &[]);
+
+    leader.handle_election_timeout();
+    assert_eq!(leader.role(), Role::Candidate);
+    assert_action!(leader, set_election_timeout());
+    assert_action!(leader, save_current_term());
+    assert_action!(leader, save_voted_for());
+
+    let Some(Action::BroadcastMessage(call @ Message::RequestVoteCall { .. })) =
+        leader.actions_mut().next()
+    else {
+        panic!("Expected RequestVoteCall message");
+    };
+    assert_no_action!(leader);
+
+    let reply = follower.asserted_handle_request_vote_call_success(&call);
+    let call = leader.asserted_handle_request_vote_reply_majority_vote_granted(&reply);
+    let reply = follower.asserted_handle_append_entries_call_failure(&call);
+    let call = leader.asserted_handle_append_entries_reply_failure(&reply);
+    let reply = follower.asserted_handle_append_entries_call_success(&call);
+    leader.asserted_handle_append_entries_reply_success(&reply, true, false);
+    assert_eq!(leader.config(), follower.config());
+
+    let joint_config = leader.config().to_joint_consensus(&[], &[follower.id()]);
+    let call = leader.asserted_change_cluster_config(joint_config);
+    let reply = follower.asserted_handle_append_entries_call_success(&call);
+
+    let final_config_prev_position = leader.log().last_position();
+    leader.handle_message(&reply);
+
+    assert_eq!(leader.config().voters, [leader.id()].into_iter().collect());
+    assert!(!leader.config().is_joint_consensus());
+    assert_eq!(leader.commit_index(), leader.log().last_position().index);
+    assert_action!(
+        leader,
+        append_log_entry(
+            final_config_prev_position,
+            cluster_config_entry(leader.config().clone())
+        )
+    );
+    assert_action!(leader, set_election_timeout());
+    assert_no_action!(leader);
+
+    let position = leader.propose_command();
+    assert_eq!(leader.commit_index(), position.index);
+    assert_action!(
+        leader,
+        append_log_entry(log_prev(position), LogEntry::Command)
+    );
+    assert_action!(leader, set_election_timeout());
+    assert_no_action!(leader);
+}
+
+#[test]
 fn create_three_nodes_cluster() {
     let mut cluster = ThreeNodeCluster::new();
     cluster.init_cluster();


### PR DESCRIPTION
## Summary

- Recompute the cached `solo_voter` flag after appending configuration entries.
- Allow a leader that shrinks the cluster to itself as the only voter to keep committing entries without requiring a restart.
- Add a fixed scenario covering the shrink-to-self voter case.
