### PR TITLE
Rebase pending log entries after snapshots

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -532,8 +532,9 @@ impl LogEntries {
         }
 
         // Rebase pending append entries to the installed snapshot. If the
-        // snapshot position is incompatible with this pending suffix, the suffix
-        // cannot be safely kept.
+        // snapshot position is incompatible with this pending suffix, it belongs
+        // to a different log branch at the snapshot boundary and must not be
+        // restored after the snapshot.
         *self = self
             .since(last_included_position)
             .unwrap_or_else(|| Self::new(last_included_position));

--- a/src/log.rs
+++ b/src/log.rs
@@ -531,13 +531,12 @@ impl LogEntries {
             return;
         }
 
-        if self.prev_position().index < last_included_position.index {
-            *self = Self::new(last_included_position);
-        } else {
-            *self = self
-                .since(last_included_position)
-                .expect("Node::handle_snapshot_installed() guarantees that this never happens");
-        }
+        // Rebase pending append entries to the installed snapshot. If the
+        // snapshot position is incompatible with this pending suffix, the suffix
+        // cannot be safely kept.
+        *self = self
+            .since(last_included_position)
+            .unwrap_or_else(|| Self::new(last_included_position));
     }
 }
 
@@ -807,6 +806,42 @@ mod tests {
         );
 
         assert_eq!(entries.since(pos(0, 3)), None); // Term mismatch
+    }
+
+    #[test]
+    fn log_entries_handle_snapshot_installed_keeps_suffix_after_snapshot_position() {
+        let mut entries = entries(
+            pos(1, 2),
+            &[
+                LogEntry::Command,
+                LogEntry::Command,
+                LogEntry::Term(Term::new(2)),
+                LogEntry::Command,
+            ],
+        );
+
+        entries.handle_snapshot_installed(pos(1, 4));
+
+        assert_eq!(entries.prev_position(), pos(1, 4));
+        assert_eq!(entries.last_position(), pos(2, 6));
+        assert_eq!(
+            entries.iter_with_positions().collect::<Vec<_>>(),
+            vec![
+                (pos(2, 5), LogEntry::Term(Term::new(2))),
+                (pos(2, 6), LogEntry::Command),
+            ]
+        );
+    }
+
+    #[test]
+    fn log_entries_handle_snapshot_installed_discards_incompatible_suffix() {
+        let mut entries = entries(pos(1, 2), &[LogEntry::Command, LogEntry::Command]);
+
+        entries.handle_snapshot_installed(pos(2, 3));
+
+        assert!(entries.is_empty());
+        assert_eq!(entries.prev_position(), pos(2, 3));
+        assert_eq!(entries.last_position(), pos(2, 3));
     }
 
     #[test]

--- a/tests/fixed_scenario_test.rs
+++ b/tests/fixed_scenario_test.rs
@@ -56,6 +56,48 @@ fn solo_voter_with_non_voter_yields_log_append_before_committed_broadcast() {
 }
 
 #[test]
+fn snapshot_preserves_pending_append_suffix_after_snapshot_position() {
+    let mut leader = TestNode::asserted_start(id(0), &[id(0)]);
+
+    let first_position = leader.propose_command();
+    let second_position = leader.propose_command();
+    assert_eq!(leader.commit_index(), second_position.index);
+    assert_eq!(
+        leader.actions().append_log_entries.as_ref(),
+        Some(&LogEntries::from_iter(
+            log_prev(first_position),
+            [LogEntry::Command, LogEntry::Command]
+        ))
+    );
+
+    let snapshot_config = leader.config().clone();
+    assert!(leader.handle_snapshot_installed(first_position, snapshot_config));
+
+    assert_eq!(leader.log().entries().prev_position(), first_position);
+    assert_eq!(leader.log().entries().last_position(), second_position);
+    assert_eq!(
+        leader.actions().append_log_entries.as_ref(),
+        Some(&LogEntries::from_iter(first_position, [LogEntry::Command]))
+    );
+}
+
+#[test]
+fn snapshot_discards_incompatible_pending_append_entries() {
+    let mut follower = Node::start(id(0));
+    assert_no_action!(follower);
+    follower.actions_mut().append_log_entries = Some(LogEntries::from_iter(
+        log_pos(t(10), i(2)),
+        [LogEntry::Command],
+    ));
+
+    let snapshot_position = log_pos(t(12), i(2));
+    assert!(follower.handle_snapshot_installed(snapshot_position, ClusterConfig::new()));
+
+    assert_eq!(follower.log().entries().prev_position(), snapshot_position);
+    assert!(follower.actions().append_log_entries.is_none());
+}
+
+#[test]
 fn create_two_nodes_cluster() {
     let initial_voters = [id(0), id(1)];
     let mut node0 = TestNode::asserted_start(id(0), &initial_voters);


### PR DESCRIPTION
## Summary

- Rebase pending `AppendLogEntries` actions when a snapshot is installed.
- Preserve pending suffix entries that remain after the snapshot position.
- Discard incompatible pending suffixes instead of panicking when the snapshot position has a different term.